### PR TITLE
Made it possible to pop to "/"

### DIFF
--- a/lib/src/url_router.dart
+++ b/lib/src/url_router.dart
@@ -117,7 +117,7 @@ class UrlRouter extends RouterDelegate<String> with ChangeNotifier, PopNavigator
     final segments = List.from(_getUri().pathSegments);
     // A null path indicates a pop vs push
     bool pop = path == null;
-    if (pop && segments.length <= 1) return; // Can't pop if we're down to 1 segment
+    if (pop && segments.length < 1) return; // Can't pop if we're down to 1 segment
     // Add or remove a segment
     pop ? segments.removeAt(segments.length - 1) : segments.add(path);
     var newUrl = '/${segments.join('/')}';


### PR DESCRIPTION
I'm not sure whether it is a correct way of achieving this, but this little change makes it possible to pop until root.

It fixes popping the "/other_route" with the following configuration (currently, it doesn't work):

```dart
    router = UrlRouter(
      onGeneratePages: (router) {
        return [
          const MaterialPage(
            child: MainPage(),
          ),
          if (router.urlPath == '/other_page')
            const MaterialPage(
              child: OtherPage(),
            ),
          if (router.urlPath == '/another_page')
            const MaterialPage(
              child: AnotherPage(),
            ),
        ];
      },
    );
```