### PR TITLE
`BuildContext` parameter for `onGeneratePages` and `onPopPage`

### DIFF
--- a/lib/src/url_router.dart
+++ b/lib/src/url_router.dart
@@ -23,7 +23,7 @@ class UrlRouter extends RouterDelegate<String> with ChangeNotifier, PopNavigator
   final Widget Function(UrlRouter router, Widget navigator)? builder;
 
   /// Optionally provide a way for the parent to implement custom `onPopPage` logic.
-  final PopPageCallback? onPopPage;
+  final bool Function(BuildContext context, Route<dynamic> route, dynamic result)? onPopPage;
 
   /// Optionally invoked just prior to the location being changed.
   /// Allows a parent class to protect or redirect certain routes. The callback can return the original url to allow the location change,
@@ -97,7 +97,9 @@ class UrlRouter extends RouterDelegate<String> with ChangeNotifier, PopNavigator
     this.context = context;
     Widget content = Navigator(
       key: _navKey,
-      onPopPage: onPopPage ?? handlePopPage,
+      onPopPage: onPopPage != null
+          ? (route, settings) => onPopPage!(context, route, settings)
+          : handlePopPage,
       pages: pages,
     );
     if (builder != null) {

--- a/lib/src/url_router.dart
+++ b/lib/src/url_router.dart
@@ -15,7 +15,7 @@ class UrlRouter extends RouterDelegate<String> with ChangeNotifier, PopNavigator
   /// Should build a stack of pages, based on the current location.
   /// This is technically optional, as you could decide to implement your
   /// own custom navigator inside the `builder`
-  final List<Page<dynamic>> Function(UrlRouter router)? onGeneratePages;
+  final List<Page<dynamic>> Function(BuildContext context, UrlRouter router)? onGeneratePages;
 
   /// Wrap widgets around the [MaterialApp]s [Navigator] widget.
   /// Primarily used for providing scaffolding like a `SideBar`, `TitleBar` around the page stack.
@@ -85,7 +85,7 @@ class UrlRouter extends RouterDelegate<String> with ChangeNotifier, PopNavigator
 
   @override
   Widget build(BuildContext context) {
-    final pages = onGeneratePages?.call(this) ?? [];
+    final pages = onGeneratePages?.call(context, this) ?? [];
     //TODO: Add more use cases for this, figure out if this is really what we want to do, or should we just always return false.
     bool handlePopPage(Route<dynamic> route, dynamic settings) {
       if (pages.length > 1 && route.didPop(settings)) {

--- a/test/core_test.dart
+++ b/test/core_test.dart
@@ -14,7 +14,7 @@ UrlRouter getSinglePageRouter([String? initial, OnChangingCallback? onChanging])
     url: initial ?? '/',
     builder: (_, navigator) => Container(child: navigator),
     onChanging: onChanging,
-    onGeneratePages: (router) {
+    onGeneratePages: (context, router) {
       return [
         /// Create a single page that renders the current url
         MaterialPage(


### PR DESCRIPTION
This is super useful for having a reactive pages generator when used in conjunction with [context_watch/context_plus](https://github.com/s0nerik/context_plus) to get something like this:
![CleanShot 2024-09-19 at 02 04 51@2x](https://github.com/user-attachments/assets/0d1fd7a7-1adc-403d-9356-7e344dbf920e)
